### PR TITLE
Replace compress/zlib with compress/flate for the encoder

### DIFF
--- a/plantuml/encode.go
+++ b/plantuml/encode.go
@@ -2,7 +2,7 @@ package plantuml
 
 import (
 	"bytes"
-	"compress/zlib"
+	"compress/flate"
 	"io"
 )
 
@@ -18,7 +18,7 @@ func DeflateAndEncode(text string) (string, error) {
 // PlantUML server.
 func DeflateAndEncodeBytes(text []byte) (string, error) {
 	var buf bytes.Buffer
-	zw, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	zw, err := flate.NewWriter(&buf, flate.BestCompression)
 	if err != nil {
 		return "", err
 	}

--- a/plantuml/encode_test.go
+++ b/plantuml/encode_test.go
@@ -11,7 +11,7 @@ func TestEncode(t *testing.T) {
 Bob -> Alice : hello
 @enduml`
 
-	expected := "UDfoA2v9B2efpStXSifFKj2rKt3CoKnELR1Io4ZDoSddSaZDIodDpG44003___W93C00"
+	expected := "SYWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKifpSq11000__y0"
 
 	encoded, err := DeflateAndEncode(source)
 


### PR DESCRIPTION
This PR replaces `compress/zlib` module with `compress/flate`. It use the deflate algorithm for encoder directly instead of using the zlib.

Take this PlantUML text for example:
```
@startuml
Bob -> Alice : hello
@enduml
```

When the encoder uses `compress/zlib`, it would be encoded as `UDfoA2v9B2efpStXSifFKj2rKt3CoKnELR1Io4ZDoSddSaZDIodDpG44003___W93C00`. But https://www.plantuml.com/plantuml/png/UDfoA2v9B2efpStXSifFKj2rKt3CoKnELR1Io4ZDoSddSaZDIodDpG44003___W93C00 is invalid.

When the encoder uses `compress/flate`, it would be encoded as `SYWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKifpSq11000__y0`. And https://www.plantuml.com/plantuml/png/SYWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKifpSq11000__y0 is valid.